### PR TITLE
Added UserRegister false to ensure that DLS users do not get the registration option

### DIFF
--- a/Auth/LearningHub.Nhs.Auth/appsettings.json
+++ b/Auth/LearningHub.Nhs.Auth/appsettings.json
@@ -336,7 +336,8 @@
         "ForgottenPasswordRelativeUrl": "forgotten-password",
         "RegisterAccountRelativeUrl": "register",
         "SupportUrl": "https://support.e-lfh.org.uk/",
-        "AllowRememberLogin": false
+        "AllowRememberLogin": false,
+        "UseRegister": false
       }
     }
   }


### PR DESCRIPTION
### JIRA link
[_TD-2454_](https://hee-tis.atlassian.net/browse/TD-2454)

### Description
Added UserRegister false to ensure that DLS users do not get the registration option

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
