### PR TITLE
TD-3841 null check on when client context is not found

### DIFF
--- a/Auth/LearningHub.Nhs.Auth/Controllers/AccountController.cs
+++ b/Auth/LearningHub.Nhs.Auth/Controllers/AccountController.cs
@@ -45,6 +45,7 @@ namespace LearningHub.Nhs.Auth.Controllers
         private readonly IAuthenticationSchemeProvider schemeProvider;
         private readonly LearningHubAuthConfig authConfig;
         private readonly WebSettings webSettings;
+        private readonly ILogger logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AccountController"/> class.
@@ -55,6 +56,7 @@ namespace LearningHub.Nhs.Auth.Controllers
         /// <param name="events">events parameter.</param>
         /// <param name="userService">userService parameter.</param>
         /// <param name="webSettings">webSettings parameter.</param>
+        /// <param name="logger">ILogger instance.</param>
         /// <param name="authConfig">Auth service config.</param>
         /// <param name="cacheService">Cacje service config.</param>
         public AccountController(
@@ -64,6 +66,7 @@ namespace LearningHub.Nhs.Auth.Controllers
             IEventService events,
             IUserService userService,
             WebSettings webSettings,
+            ILogger<AccountController> logger,
             IOptions<LearningHubAuthConfig> authConfig,
             ICacheService cacheService)
             : base(userService, events, clientStore, webSettings, cacheService)
@@ -72,6 +75,7 @@ namespace LearningHub.Nhs.Auth.Controllers
             this.schemeProvider = schemeProvider;
             this.authConfig = authConfig?.Value;
             this.webSettings = webSettings;
+            this.logger = logger;
     }
 
         /// <summary>
@@ -394,6 +398,12 @@ namespace LearningHub.Nhs.Auth.Controllers
                         providers = providers.Where(provider => client.IdentityProviderRestrictions.Contains(provider.AuthenticationScheme)).ToList();
                     }
                 }
+            }
+
+            if (context == null || loginClientTemplate == null)
+            {
+                string message = context == null ? "context" : loginClientTemplate == null ? "clientTemplate" : string.Empty;
+                this.logger.LogWarning($"return url has no {message} : {returnUrl}");
             }
 
             return new LoginViewModel

--- a/Auth/LearningHub.Nhs.Auth/Controllers/AccountController.cs
+++ b/Auth/LearningHub.Nhs.Auth/Controllers/AccountController.cs
@@ -336,7 +336,7 @@ namespace LearningHub.Nhs.Auth.Controllers
         {
             var context = await this.interaction.GetAuthorizationContextAsync(returnUrl);
             LoginClientTemplate loginClientTemplate = null;
-            if (context?.Client.ClientId != null && this.authConfig.IdsClients.ContainsKey(context.Client.ClientId))
+            if (context?.Client?.ClientId != null && this.authConfig.IdsClients.ContainsKey(context.Client.ClientId))
             {
                 loginClientTemplate = this.authConfig.IdsClients[context.Client.ClientId];
 
@@ -383,7 +383,7 @@ namespace LearningHub.Nhs.Auth.Controllers
 
             var allowLocal = true;
 
-            if (context?.Client.ClientId != null)
+            if (context?.Client?.ClientId != null)
             {
                 var client = await this.ClientStore.FindEnabledClientByIdAsync(context.Client.ClientId);
                 if (client != null)
@@ -404,7 +404,7 @@ namespace LearningHub.Nhs.Auth.Controllers
                 Username = context?.LoginHint,
                 ExternalProviders = providers.ToArray(),
                 LoginClientTemplate = loginClientTemplate ?? new LoginClientTemplate(),
-                ClientId = context?.Client.ClientId,
+                ClientId = context?.Client?.ClientId,
             };
         }
 


### PR DESCRIPTION
### JIRA link
[TD-3841](https://hee-tis.atlassian.net/browse/TD-3841)

### Description
further null checks carried out when client context is not found.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3841]: https://hee-tis.atlassian.net/browse/TD-3841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ