### PR TITLE
 TD-3744 -Job role with slash in causes error during registration

### DIFF
--- a/LearningHub.Nhs.UserApi/Controllers/JobRoleController.cs
+++ b/LearningHub.Nhs.UserApi/Controllers/JobRoleController.cs
@@ -5,9 +5,11 @@
     using System.Linq;
     using System.Threading.Tasks;
     using elfhHub.Nhs.Models.Common;
+    using LearningHub.Nhs.UserApi.Helpers;
     using LearningHub.Nhs.UserApi.Services.Interface;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
+    using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// The job role controller.
@@ -100,7 +102,7 @@
         [Route("GetPagedFilteredWithStaffGroup/{filter}/{page}/{pageSize}")]
         public async Task<Tuple<int, List<JobRoleBasicViewModel>>> GetPagedFilteredWithStaffGroup(string filter, int page, int pageSize)
         {
-            var list = await this.jobRoleService.GetFilteredWithStaffGroupAsync(filter);
+            var list = await this.jobRoleService.GetFilteredWithStaffGroupAsync(filter.DecodeParameter());
             int total = list.Count;
             var pagedList = list.Skip((page - 1) * pageSize).Take(pageSize).ToList();
             return new Tuple<int, List<JobRoleBasicViewModel>>(total, pagedList);


### PR DESCRIPTION
### JIRA link
TD-3744

### Description
_Job role with slash in causes error during registration
### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/assets/154979799/2af8fbfd-fd84-410a-a87e-839a19d80473)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
