### PR TITLE
Add authentication config for User Profile Client

### DIFF
--- a/Auth/LearningHub.Nhs.Auth/Configuration/LearningHubResourceStore.cs
+++ b/Auth/LearningHub.Nhs.Auth/Configuration/LearningHubResourceStore.cs
@@ -26,12 +26,14 @@
             {
                 new ApiResource("learninghubapi", "Learning Hub API") { Scopes = new List<string> { "learninghubapi", }, },
                 new ApiResource("userapi", "User API") { Scopes = new List<string> { "userapi" } },
+                new ApiResource("learningcredentialsapi", "Learning Credentials API") { Scopes = new List<string> { "learningcredentialsapi" } },
             };
 
             this.apiScopes = new[]
             {
                 new ApiScope("learninghubapi", "Access Learning Hub API"),
                 new ApiScope("userapi", "Access User API"),
+                new ApiScope("learningcredentialsapi", "Learning Credentials API"),
             };
 
             this.identityResources = new[]

--- a/Auth/LearningHub.Nhs.Auth/appsettings.json
+++ b/Auth/LearningHub.Nhs.Auth/appsettings.json
@@ -137,6 +137,21 @@
         "RequirePkce": false,
         "AllowOfflineAccess": false
       },
+      "userprofileclient": {
+        "BaseUrl": "",
+        "ClientName": "",
+        "ClientSecret": "",
+        "AllowedGrantTypes": [ "" ],
+        "RedirectUris": [ "" ],
+        "PostLogoutUris": [ "" ],
+        "AllowedScopes": [ "", "", "", "", "", "" ],
+        "BackChannelLogoutSessionRequired": true,
+        "BackChannelLogoutUri": "",
+        "UpdateAccessTokenClaimsOnRefresh": true,
+        "RequireConsent": false,
+        "RequirePkce": true,
+        "AllowOfflineAccess": true
+      },
       "learninghubopenapi": {
         "BaseUrl": "",
         "ClientName": "",


### PR DESCRIPTION
### JIRA link
_TD-4246_https://hee-tis.atlassian.net/browse/TD-4246

### Description
Additional configuration has been added to allow User Profile (part of Digital Staff Passport) to use the existing LH authentication mechanism.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
