### PR TITLE
TD-4184: DIG414: Focus doesn't move to field or error on submit

### DIFF
--- a/Auth/LearningHub.Nhs.Auth/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/Auth/LearningHub.Nhs.Auth/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -18,29 +18,44 @@
 </environment>
 <script type="text/javascript">
   // Add/remove class 'input-validation-error' to the div containing the control with error
-  $(function () {
-    $('form').each(function () {
-      if ($(this).data("validator")) {
-        var valSettings = $(this).data("validator").settings
-        valSettings.highlight = wrap($.validator.defaults.highlight, highlightDecorator)
-        valSettings.unhighlight = wrap($.validator.defaults.unhighlight, unhighlightDecorator)
-      }
+
+    let errorElements = [];
+    let submitAttempted = false;
+    document.querySelector('form').onsubmit = () => { submitAttempted = true; }
+ 
+    $(function () {
+        $('form').each(function () {
+            if ($(this).data("validator")) {
+                var valSettings = $(this).data("validator").settings;
+                 valSettings.highlight = wrap($.validator.defaults.highlight, highlightDecorator);
+                valSettings.unhighlight = wrap($.validator.defaults.unhighlight, unhighlightDecorator);
+            }
+        });
     });
-  });
 
-  function wrap(functionToWrap, beforeFunction) {
-    return function () {
-      var args = Array.prototype.slice.call(arguments);
-      beforeFunction.apply(this, args);
-      return functionToWrap.apply(this, args);
+   function wrap(functionToWrap, beforeFunction) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            beforeFunction.apply(this, args);
+            if (errorElements.length && submitAttempted) {
+               errorElements[0]['obj'].focus();
+                submitAttempted = false;
+            }
+
+            return functionToWrap.apply(this, args);
+        };
     };
-  };
 
-  function highlightDecorator(element, errorClass, validClass) {
-    $(element).closest("div").addClass(errorClass).removeClass(validClass);
-  }
-  function unhighlightDecorator(element, errorClass, validClass) {
-    $(element).closest("div").addClass(validClass).removeClass(errorClass);
-  }
+    function highlightDecorator(element, errorClass, validClass) {
+        $(element).closest("div").addClass(errorClass).removeClass(validClass);
+        let itemExists = errorElements.some(obj => obj['id'] == element.id);
+        if (!itemExists) {
+            errorElements.push({ 'id': element.id, 'obj': element });
+        }
+    }
+    function unhighlightDecorator(element, errorClass, validClass) {
+        $(element).closest("div").addClass(validClass).removeClass(errorClass);
+        errorElements = errorElements.filter((elm) => elm.id != element.id);
+    }
 
 </script>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4184

### Description
 Now, tested by entering username and left blank password field, focus is navigating to password field. Again tested entering password on ‘password’ field and left blank ‘username’ field. Focus navigating to ‘username’ field. This is also fine. But at the same time if we clear ‘password’ field and left blank both fields and clicking ‘submit’ button focus is now navigating to second field ‘Password’ one instead of ‘username’ field. Here, always the focus needs to navigate to first field. This issue exists on both screens and needs to be fixed - fixed the issue

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
