### PR TITLE
 TD-4180: Moved client side validations to server side.

### DIFF
--- a/Auth/LearningHub.Nhs.Auth/Views/Account/LHLogin.cshtml
+++ b/Auth/LearningHub.Nhs.Auth/Views/Account/LHLogin.cshtml
@@ -2,6 +2,7 @@
 @{
   ViewData["Title"] = "Login";
   ViewData["Layout"] = "learninghub/_Layout";
+  ViewData["DisableValidation"] = true;
   // OpenAthens url needs to makes sure that the return to WebUI first hits the authorisationrequired endpoint,
   // which contains it's own redirect to within the UI.
   // If a return url is specified we want to use it for the authorisationrequired original url

--- a/Auth/LearningHub.Nhs.Auth/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/Auth/LearningHub.Nhs.Auth/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,8 +1,10 @@
-<environment include="Development">
-  <script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
-  <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
-</environment>
-<environment exclude="Development">
+@if (!ViewData["DisableValidation"]?.Equals(true) ?? true)
+{
+  <environment include="Development">
+    <script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
+    <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
+    </environment>
+  <environment exclude="Development">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"
           asp-fallback-src="~/lib/jquery-validation/dist/jquery.validate.min.js"
           asp-fallback-test="window.jQuery && window.jQuery.validator"
@@ -15,7 +17,8 @@
           crossorigin="anonymous"
           integrity="sha256-9GycpJnliUjJDVDqP0UEu/bsm9U+3dnQUH8+3W10vkY=">
   </script>
-</environment>
+  </environment>
+}
 <script type="text/javascript">
   // Add/remove class 'input-validation-error' to the div containing the control with error
 


### PR DESCRIPTION
### JIRA link
_[TD-4180](https://hee-tis.atlassian.net/browse/TD-4180)_

### Description
Conditionally removed validation js from LH login page.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4180]: https://hee-tis.atlassian.net/browse/TD-4180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ