### PR TITLE
TD-3731: Password Change Does Not Invalidate Current Session

### DIFF
--- a/Auth/LearningHub.Nhs.Auth/Configuration/WebSettings.cs
+++ b/Auth/LearningHub.Nhs.Auth/Configuration/WebSettings.cs
@@ -56,5 +56,10 @@
         /// Gets or sets the SupportFeedbackForm.
         /// </summary>
         public string SupportFeedbackForm { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether IsPasswordUpdate.
+        /// </summary>
+        public bool IsPasswordUpdate { get; set; }
   }
 }

--- a/Auth/LearningHub.Nhs.Auth/Controllers/HomeController.cs
+++ b/Auth/LearningHub.Nhs.Auth/Controllers/HomeController.cs
@@ -81,6 +81,27 @@
         }
 
         /// <summary>
+        /// IsPasswordUpdateMethod.
+        /// </summary>
+        /// <param name="isLogout">The Logout.</param>
+        /// <returns>The <see cref="ActionResult"/>.</returns>
+        [HttpGet]
+        public IActionResult SetIsPasswordUpdate(bool isLogout)
+        {
+            if (isLogout)
+            {
+                this.webSettings.IsPasswordUpdate = false;
+            }
+            else
+            {
+                this.webSettings.IsPasswordUpdate = true;
+            }
+
+            var redirectUri = $"{this.webSettings.LearningHubWebClient}Home/UserLogout";
+            return this.Redirect(redirectUri);
+        }
+
+        /// <summary>
         /// Shows the HealthCheck response.
         /// </summary>
         /// <returns>HealthCheck.</returns>

--- a/Auth/LearningHub.Nhs.Auth/appsettings.json
+++ b/Auth/LearningHub.Nhs.Auth/appsettings.json
@@ -39,9 +39,8 @@
     "ElfhHub": "",
     "Rcr": "",
     "SupportForm": "https://support.learninghub.nhs.uk/support/tickets/new",
-    "SupportFeedbackForm": "https://forms.office.com/e/C8tteweEhG"
-
-
+    "SupportFeedbackForm": "https://forms.office.com/e/C8tteweEhG",
+    "IsPasswordUpdate": "false"
   },
   "AllowOpenAthensDebug": false,
   "OaLhClients": {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3731

### Description
Invalidated Current User Session on Password Change.

### Screenshots
![image](https://github.com/user-attachments/assets/26280883-6a97-469f-9d55-2e17c7da3322)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
