### PR TITLE
TD-5790: Save Successful email transactions for One-off emails

### DIFF
--- a/LearningHub.Nhs.UserApi.Services.UnitTests/RegistrationServiceTests.cs
+++ b/LearningHub.Nhs.UserApi.Services.UnitTests/RegistrationServiceTests.cs
@@ -51,7 +51,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var status = await registrationService.GetRegistrationStatus("test@here.com", this.ipAddress);
 
             Assert.IsType<EmailRegistrationStatus>(status);
@@ -79,7 +79,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, userGroupRepositoryMock.Object, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, userGroupRepositoryMock.Object, null, null, null, this.countryLookupRepoMock.Object, null);
             var status = await registrationService.GetRegistrationStatus("test@here.com", this.ipAddress);
 
             Assert.IsType<EmailRegistrationStatus>(status);
@@ -103,7 +103,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var status = await registrationService.GetRegistrationStatus("test@here.com", this.ipAddress);
 
             Assert.IsType<EmailRegistrationStatus>(status);
@@ -127,7 +127,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var status = await registrationService.GetRegistrationStatus("test@here.com", this.ipAddress);
 
             Assert.IsType<EmailRegistrationStatus>(status);
@@ -145,7 +145,7 @@
         {
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(null, null, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(null, null, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {
@@ -177,7 +177,7 @@
         {
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(null, null, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(null, null, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {
@@ -207,7 +207,7 @@
         {
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(null, null, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(null, null, null, null, null, null, null, null, null, null, null, null, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {
@@ -252,7 +252,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, medicalcouncilServiceMock.Object, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, medicalcouncilServiceMock.Object, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {
@@ -294,7 +294,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, medicalcouncilServiceMock.Object, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, medicalcouncilServiceMock.Object, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {
@@ -336,7 +336,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, medicalcouncilServiceMock.Object, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, medicalcouncilServiceMock.Object, null, null, optionsMock.Object, null, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {
@@ -381,7 +381,7 @@
 
             var optionsMock = new Mock<IOptions<Settings>>();
 
-            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, null, userServiceMock.Object, null, optionsMock.Object, null, medicalCouncilRepositoryMock.Object, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(null, null, jobRoleRepositoryMock.Object, null, null, null, null, null, null, null, null, null, userServiceMock.Object, null, optionsMock.Object, null, medicalCouncilRepositoryMock.Object, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {
@@ -456,7 +456,7 @@
             var emailLogRepositoryMock = new Mock<IEmailLogRepository>();
             emailLogRepositoryMock.Setup(r => r.CreateAsync(It.IsAny<int>(), It.IsAny<EmailLog>()));
 
-            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, jobRoleRepositoryMock.Object, userUserGroupRepositoryMock.Object, userEmploymentRepositoryMock.Object, emailTemplateRepositoryMock.Object, emailLogRepositoryMock.Object, systemSettingsRepositoryMock.Object, userPasswordValidationTokenRepositoryMock.Object, tenantRepositoryMock.Object, tenantSmtpRepositoryMock.Object, null, userServiceMock.Object, userHistoryServiceMock.Object, this.GetSettings(), loginWizardServiceMock.Object, null, null, null, null, null, this.countryLookupRepoMock.Object);
+            var registrationService = new RegistrationService(userRepositoryMock.Object, userGroupTypeInputValidationRepositoryMock.Object, jobRoleRepositoryMock.Object, userUserGroupRepositoryMock.Object, userEmploymentRepositoryMock.Object, emailTemplateRepositoryMock.Object, emailLogRepositoryMock.Object, systemSettingsRepositoryMock.Object, userPasswordValidationTokenRepositoryMock.Object, tenantRepositoryMock.Object, tenantSmtpRepositoryMock.Object, null, userServiceMock.Object, userHistoryServiceMock.Object, this.GetSettings(), loginWizardServiceMock.Object, null, null, null, null, null, this.countryLookupRepoMock.Object, null);
             var validationResult = await registrationService.RegisterUser(
                 new RegistrationRequestViewModel()
                 {

--- a/LearningHub.Nhs.UserApi.Services.UnitTests/UserServiceTests.cs
+++ b/LearningHub.Nhs.UserApi.Services.UnitTests/UserServiceTests.cs
@@ -543,6 +543,7 @@
                 null,
                 null,
                 null,
+                null,
                 null);
 
             var role = await userService.GetUserRoleAsync(1);
@@ -571,6 +572,7 @@
             var userService = new ElfhUserService(
                 null,
                 userGroupRepositoryMock.Object,
+                null,
                 null,
                 null,
                 null,
@@ -836,6 +838,7 @@
                 null,
                 null,
                 null,
+                null,
                 null);
 
             var role = await userService.GetUserRoleAsync(1);
@@ -885,6 +888,7 @@
                 null,
                 null,
                 this.NewMapper(),
+                null,
                 null);
 
             await userService.UpdateUserSecurityQuestions(userSecurityQuestions, userId);
@@ -936,6 +940,7 @@
                 null,
                 null,
                 this.NewMapper(),
+                null,
                 null);
 
             await userService.UpdateUserSecurityQuestions(userSecurityQuestions, userId);
@@ -977,6 +982,7 @@
                 this.elfhCacheSettingOptions,
                 elfhCacheMock.Object,
                 this.NewMapper(),
+                null,
                 null);
 
             await userService.InvalidateElfhUserCacheAsync(123456, "test.user", CancellationToken.None);

--- a/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
+++ b/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
@@ -673,13 +673,14 @@
             await this.userPasswordValidationTokenRepository.CreateAsync(userId, userPasswordValidationToken);
 
             var personalisation = new Dictionary<string, dynamic>();
-            personalisation["name"] = (user.FirstName + " " + user.LastName).ToTitleCase();
+            personalisation["name"] = user.FirstName;
             personalisation["username"] = user.UserName;
+            personalisation["new password"] = userPasswordValidationToken.ValidateUrl;
 
             var emailRequest = new EmailRequest
             {
                 Recipient = user.EmailAddress,
-                TemplateId = "a6574e74-8769-417b-90ef-c4a4a1be5250",
+                TemplateId = this.settings.Value.GovNotifyTemplates.ForgottenUsernameOrPassword,
                 Personalisation = personalisation,
             };
 
@@ -743,13 +744,14 @@
             await this.userPasswordValidationTokenRepository.CreateAsync(user.Id, userPasswordValidationToken);
 
             var personalisation = new Dictionary<string, dynamic>();
-            personalisation["name"] = (user.FirstName + " " + user.LastName).ToTitleCase();
+            personalisation["name"] = user.FirstName;
             personalisation["username"] = user.UserName;
+            personalisation["new password"] = userPasswordValidationToken.ValidateUrl;
 
             var emailRequest = new EmailRequest
             {
                 Recipient = user.EmailAddress,
-                TemplateId = "a6574e74-8769-417b-90ef-c4a4a1be5250",
+                TemplateId = this.settings.Value.GovNotifyTemplates.ForgottenUsernameOrPassword,
                 Personalisation = personalisation,
             };
 

--- a/LearningHub.Nhs.UserApi.Services/RegistrationService.cs
+++ b/LearningHub.Nhs.UserApi.Services/RegistrationService.cs
@@ -354,13 +354,14 @@
                     await this.userPasswordValidationTokenRepository.CreateAsync(userId, userPasswordValidationToken);
 
                     var personalisation = new Dictionary<string, dynamic>();
-                    personalisation["name"] = (newUser.FirstName + " " + newUser.LastName).ToTitleCase();
+                    personalisation["name"] = newUser.FirstName;
                     personalisation["username"] = newUser.UserName;
+                    personalisation["password"] = userPasswordValidationToken.ValidateUrl;
 
                     var emailRequest = new EmailRequest
                     {
                         Recipient = registrationRequest.EmailAddress,
-                        TemplateId = "fc3752d7-4c04-4d40-87fd-ad1264072ae9",
+                        TemplateId = this.settings.GovNotifyTemplates.NHSLearningHubRegistration,
                         Personalisation = personalisation,
                     };
 

--- a/LearningHub.Nhs.UserApi.Shared/Configuration/GovNotifyTemplates.cs
+++ b/LearningHub.Nhs.UserApi.Shared/Configuration/GovNotifyTemplates.cs
@@ -1,0 +1,18 @@
+﻿namespace LearningHub.Nhs.UserApi.Shared.Configuration
+{
+    /// <summary>
+    /// GovNotifyTemplates.
+    /// </summary>
+    public class GovNotifyTemplates
+    {
+        /// <summary>
+        /// Gets or sets the ForgottenUsernameOrPassword ID.
+        /// </summary>
+        public string ForgottenUsernameOrPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NHSLearningHubRegistration ID.
+        /// </summary>
+        public string NHSLearningHubRegistration { get; set; }
+    }
+}

--- a/LearningHub.Nhs.UserApi.Shared/Configuration/Settings.cs
+++ b/LearningHub.Nhs.UserApi.Shared/Configuration/Settings.cs
@@ -49,5 +49,10 @@
         /// Gets or sets the security questions required.
         /// </summary>
         public int SecurityQuestionsRequired { get; set; }
+
+        /// <summary>
+        /// Gets or sets the GovNotifyTemplates.
+        /// </summary>
+        public GovNotifyTemplates GovNotifyTemplates { get; set; }
     }
 }

--- a/LearningHub.Nhs.UserApi/appsettings.json
+++ b/LearningHub.Nhs.UserApi/appsettings.json
@@ -36,7 +36,11 @@
       "ElfhUserLoadByUserIdKey": "",
       "ElfhUserLoadByUserNameKey": ""
     },
-    "SecurityQuestionsRequired": 2
+    "SecurityQuestionsRequired": 2,
+    "GovNotifyTemplates": {
+      "ForgottenUsernameOrPassword": "",
+      "NHSLearningHubRegistration": ""
+    }
   },
   "OpenApiConfig": {
     "OpenApiUrl": "",


### PR DESCRIPTION
### JIRA link
_TD-[5790](https://hee-tis.atlassian.net/browse/TD-5790)_

### Description
_Save Successful email transactions for One off emails. Earlier stored only failed transactions, now we can get hold on to all transactions._

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
