### PR TITLE
TD-6335-Users are exploiting the certificate generation system on elfh and Learning Hub by changing account names to reproduce certificates under multiple identities.

### DIFF
--- a/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
+++ b/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
@@ -237,7 +237,7 @@
 
             await this.elfhUserRepository.UpdateAsync(id, user);
 
-           // await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
+            await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
         }
 
         /// <inheritdoc/>
@@ -250,7 +250,7 @@
 
             await this.elfhUserRepository.UpdateAsync(id, user);
 
-           // await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
+            await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
         }
 
         /// <inheritdoc/>

--- a/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
+++ b/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
@@ -237,7 +237,7 @@
 
             await this.elfhUserRepository.UpdateAsync(id, user);
 
-            await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
+           // await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
         }
 
         /// <inheritdoc/>
@@ -250,7 +250,7 @@
 
             await this.elfhUserRepository.UpdateAsync(id, user);
 
-            await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
+           // await this.InvalidateElfhUserCacheAsync(user.Id, user.UserName, token);
         }
 
         /// <inheritdoc/>
@@ -977,8 +977,6 @@
         public async Task UpdateMyAccountPersonalDetails(PersonalDetailsViewModel personalDetailsViewModel, int currentUserId)
         {
             User user = await this.elfhUserRepository.GetByIdAsync(personalDetailsViewModel.UserId);
-            user.FirstName = personalDetailsViewModel.FirstName;
-            user.LastName = personalDetailsViewModel.LastName;
             user.PreferredName = personalDetailsViewModel.PreferredName;
             user.AltEmailAddress = personalDetailsViewModel.SecondaryEmailAddress;
 


### PR DESCRIPTION
### JIRA link
TD-6335

### Description
Users are exploiting the certificate generation system on elfh and Learning Hub by changing account names to reproduce certificates under multiple identities.
### Screenshots
<img width="860" height="520" alt="image" src="https://github.com/user-attachments/assets/2b1999f0-395d-4827-bee1-13448ab13479" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [X] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
