### PR TITLE
TD-5278-Remove the year from the Footer copyright notice

### DIFF
--- a/Auth/LearningHub.Nhs.Auth/Views/Shared/LearningHub/_FooterPartial.cshtml
+++ b/Auth/LearningHub.Nhs.Auth/Views/Shared/LearningHub/_FooterPartial.cshtml
@@ -1,7 +1,7 @@
 <footer role="contentinfo">
   <div class="nhsuk-footer" id="nhsuk-footer">
     <div class="nhsuk-width-container nhsuk-footer__container app-width-container">
-      <p class="nhsuk-footer__copyright">&copy; NHS England @DateTime.Now.Year</p>
+      <p class="nhsuk-footer__copyright">&copy; NHS England</p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
### JIRA link
_TD-5278_

### Description
Removed the year from the Footer copyright notice

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
