### PR TITLE
TD-7354: GovNotify dashboard entries timing is incorrect

### DIFF
--- a/Auth/LearningHub.Nhs.Auth.Tests/LearningHub.Nhs.Auth.Tests.csproj
+++ b/Auth/LearningHub.Nhs.Auth.Tests/LearningHub.Nhs.Auth.Tests.csproj
@@ -10,7 +10,7 @@
   
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/Auth/LearningHub.Nhs.Auth/LearningHub.Nhs.Auth.csproj
+++ b/Auth/LearningHub.Nhs.Auth/LearningHub.Nhs.Auth.csproj
@@ -106,7 +106,7 @@
 		<PackageReference Include="IdentityServer4" Version="4.1.2" />
 		<PackageReference Include="IdentityServer4.Contrib.RedisStore" Version="4.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />

--- a/LearningHub.Nhs.UserApi.Repository.Interface/LearningHub.Nhs.UserApi.Repository.Interface.csproj
+++ b/LearningHub.Nhs.UserApi.Repository.Interface/LearningHub.Nhs.UserApi.Repository.Interface.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LearningHub.Nhs.UserApi.Repository/LearningHub.Nhs.UserApi.Repository.csproj
+++ b/LearningHub.Nhs.UserApi.Repository/LearningHub.Nhs.UserApi.Repository.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/LearningHub.Nhs.UserApi.Services.Interface/IElfhUserService.cs
+++ b/LearningHub.Nhs.UserApi.Services.Interface/IElfhUserService.cs
@@ -230,15 +230,15 @@
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         Task<PersonalDetailsViewModel> GetPersonalDetailsAsync(int currentUserId);
 
-            /// <summary>
-            /// The does email address exist async.
-            /// </summary>
-            /// <param name="emailAddress">
-            /// The email address.
-            /// </param>
-            /// <returns>
-            /// The <see cref="Task"/>.
-            /// </returns>
+        /// <summary>
+        /// The does email address exist async.
+        /// </summary>
+        /// <param name="emailAddress">
+        /// The email address.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Task"/>.
+        /// </returns>
         Task<bool> DoesEmailAddressExistAsync(string emailAddress);
 
         /// <summary>
@@ -335,10 +335,13 @@
         /// <param name="emailAddress">
         /// The email address.
         /// </param>
+        /// <param name="tzOffset">
+        /// The timeOffset.
+        /// </param>
         /// <returns>
         /// The <see cref="Task"/>.
         /// </returns>
-        Task SendForgotPasswordEmail(string emailAddress);
+        Task SendForgotPasswordEmail(string emailAddress, int? tzOffset);
 
         /// <summary>
         /// Sends email to user.
@@ -528,5 +531,5 @@
         /// <param name="currentUserId">currentUserId.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         Task UpdateMyAccountPersonalDetails(PersonalDetailsViewModel personalDetailsViewModel, int currentUserId);
-  }
+    }
 }

--- a/LearningHub.Nhs.UserApi.Services.Interface/LearningHub.Nhs.UserAPI.Services.Interface.csproj
+++ b/LearningHub.Nhs.UserApi.Services.Interface/LearningHub.Nhs.UserAPI.Services.Interface.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LearningHub.Nhs.UserApi.Services.UnitTests/LearningHub.Nhs.UserApi.Services.UnitTests.csproj
+++ b/LearningHub.Nhs.UserApi.Services.UnitTests/LearningHub.Nhs.UserApi.Services.UnitTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
     <PackageReference Include="EntityFrameworkCore.Testing.Moq" Version="5.0.0" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 	  <PackageReference Include="MockQueryable.Core" Version="7.0.3" />
 	  <PackageReference Include="MockQueryable.Moq" Version="5.0.0" />

--- a/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
+++ b/LearningHub.Nhs.UserApi.Services/ElfhUserService.cs
@@ -732,7 +732,7 @@
         }
 
         /// <inheritdoc/>
-        public async Task SendForgotPasswordEmail(string emailAddress)
+        public async Task SendForgotPasswordEmail(string emailAddress, int? tzOffset)
         {
             var user = this.elfhUserRepository.GetAll().SingleOrDefault(x => x.EmailAddress == emailAddress);
             if (user == null)
@@ -754,6 +754,7 @@
                 Recipient = user.EmailAddress,
                 TemplateId = this.settings.Value.GovNotifyTemplates.ForgottenUsernameOrPassword,
                 Personalisation = personalisation,
+                TimezoneOffset = tzOffset,
             };
 
             var client = this.openApiHttpClient.GetClient();

--- a/LearningHub.Nhs.UserApi.Services/LearningHub.Nhs.UserApi.Services.csproj
+++ b/LearningHub.Nhs.UserApi.Services/LearningHub.Nhs.UserApi.Services.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/LearningHub.Nhs.UserApi.Shared/LearningHub.Nhs.UserApi.Shared.csproj
+++ b/LearningHub.Nhs.UserApi.Shared/LearningHub.Nhs.UserApi.Shared.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LearningHub.Nhs.UserApi.UnitTests/LearningHub.Nhs.UserApi.UnitTests.csproj
+++ b/LearningHub.Nhs.UserApi.UnitTests/LearningHub.Nhs.UserApi.UnitTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/LearningHub.Nhs.UserApi/Controllers/ElfhUserController.cs
+++ b/LearningHub.Nhs.UserApi/Controllers/ElfhUserController.cs
@@ -749,15 +749,16 @@
         /// <param name="model">
         /// The model.
         /// </param>
+        /// <param name="timeoffset">The timeOffset.</param>
         /// <returns>
         /// The <see cref="Task"/>.
         /// </returns>
         [HttpPost]
         [AllowAnonymous]
         [Route("ForgotPassword")]
-        public async Task<IActionResult> ForgotPassword(ForgotPasswordViewModel model)
+        public async Task<IActionResult> ForgotPassword(ForgotPasswordViewModel model, [FromQuery] int? timeoffset)
         {
-            await this.ElfhUserService.SendForgotPasswordEmail(model.EmailAddress);
+            await this.ElfhUserService.SendForgotPasswordEmail(model.EmailAddress, timeoffset);
             return this.Ok(new ApiResponse(true));
         }
 

--- a/LearningHub.Nhs.UserApi/LearningHub.Nhs.UserApi.csproj
+++ b/LearningHub.Nhs.UserApi/LearningHub.Nhs.UserApi.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.13" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.36" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.15.0" />


### PR DESCRIPTION
### JIRA link
_TD-7354_

### Description
GovNotify dashboard entries timing is incorrect

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
